### PR TITLE
HCL auto-update on new TRH/TUC versions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,2 @@
 #### Motivation for this change and description of the change
 
-#### Checklist
-
-- [ ] All commits have been signed

--- a/.github/workflows/update-hcls.yml
+++ b/.github/workflows/update-hcls.yml
@@ -1,0 +1,30 @@
+name: 'Automatic HCL Update in Pull Requests'
+
+on:
+  # Only run on internal pull requests
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  update-hcls:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@v6.0.1
+        with:
+          ref: '${{ github.event.pull_request.head.ref }}'
+      - name: 'Update HCLs'
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cd "${{ github.workspace }}/"
+          ./script/hcl-update.sh
+      - name: 'Commit changes to pull request'
+        uses: EndBug/add-and-commit@v9.1.4
+        with:
+            add: '["bin/packages/trh.hcl", "bin/packages/tuc.hcl"]'
+            message: 'Hermit upgrade TUC and TRH, adding digests'
+            author_name: 'githubactions[bot]'
+            author_email: 'githubactions[bot]@users.noreply.github.com'

--- a/script/hcl-update.sh
+++ b/script/hcl-update.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# update trh.hcl and tuc.hcl according to the given versions
+# version strings need to be manually updated in the hcl files before running
+# this script.
+
+set -euxo pipefail
+
+# shellcheck source=/dev/null
+source bin/activate-hermit
+hermit upgrade tuc trh
+hermit manifest add-digests bin/packages/trh.hcl bin/packages/tuc.hcl


### PR DESCRIPTION


#### Motivation for this change and description of the change
Automate the HCL update process on new incoming TRH/TUC versions.

#### Checklist

- [x] All commits have been signed
